### PR TITLE
Fix repo review issues: typos, stray dependency, CI gaps, ESLint config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,21 +1,38 @@
 name: CI/CD
 
 on:
+  push:
+    branches: [main]
+  pull_request:
   release:
     types: [created]
 
 jobs:
-  build:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run test
+
+  publish:
+    if: github.event_name == 'release'
+    needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/
       - run: npm ci
-      - run: npm run lint
-      - run: npm run test
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Removed `npm` from production dependencies
+- Corrected `sanatize` typo to `sanitize` throughout codebase
+- Fixed README incorrectly claiming zero dependencies
+- Fixed ESLint globals configured for browser instead of Node.js
+- Added CI triggers for push and pull_request events (previously only ran on release)
+- Upgraded GitHub Actions from v2 to v4
+- Added Node.js version matrix (18, 20, 22) to CI
+- Added tests for disabled sanitization options and `$`-prefixed value stripping
+- Server now properly closed after tests
+
 ## [1.2.5] - 2025-02-21
 ### Changed
 - upgraded NPM dependencies

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![CI/CD](https://github.com/KlemenKozelj/fastify-mongodb-sanitizer/actions/workflows/main.yml/badge.svg) ![Vulnerabilities](https://snyk.io/test/github/KlemenKozelj/fastify-mongodb-sanitizer/badge.svg)
 
-Slim, well tested and zero dependencies Fastify plugin which through middleware sanitizes all user server inputs to increase overall security by preventing potential MongoDB database query injection attacks.
+Slim, well tested Fastify plugin which through middleware sanitizes all user server inputs to increase overall security by preventing potential MongoDB database query injection attacks.
 To further tighten the security please consider disabling server-side execution of JavaScript code or be extra cautious when running `$where` and `MapReduce` commands, taken from [MongoDB FAQ](https://www.mongodb.com/docs/manual/faq/fundamentals/#javascript).
 
 
@@ -47,7 +47,7 @@ server.inject({
     },
 })
 ```
-sanatizer will remove all keys and values starting with $, expected result in handler function will be:
+sanitizer will remove all keys and values starting with $, expected result in handler function will be:
 ```js
 function requestHandler(req, res) {
     req.params // {}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,6 @@ import pluginJs from "@eslint/js";
 
 export default [
   {files: ["**/*.js"], languageOptions: {sourceType: "commonjs"}},
-  {languageOptions: { globals: globals.browser }},
+  {languageOptions: { globals: globals.node }},
   pluginJs.configs.recommended,
 ];

--- a/index.js
+++ b/index.js
@@ -1,17 +1,17 @@
 const fastifyPlugin = require('fastify-plugin');
-const sanatize = require('./src/sanitizer');
+const sanitize = require('./src/sanitizer');
 
 module.exports = fastifyPlugin(async (fastify, { params = true, query = true, body = true }) => {
   fastify
     .addHook('preHandler', async (req) => {
       if (params) {
-        req.params = sanatize(req.params);
+        req.params = sanitize(req.params);
       }
       if (query) {
-        req.query = sanatize(req.query);
+        req.query = sanitize(req.query);
       }
       if (body) {
-        req.body = sanatize(req.body);
+        req.body = sanitize(req.body);
       }
     });
 }, {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   },
   "homepage": "https://github.com/KlemenKozelj/fastify-mongodb-sanitizer#readme",
   "dependencies": {
-    "fastify-plugin": "^5.0.1",
-    "npm": "^11.1.0"
+    "fastify-plugin": "^5.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -2,7 +2,7 @@ const isValueObject = (o) => typeof o === 'object' && o !== null;
 
 const startsWith$ = (v) => typeof v === 'string' && v.startsWith('$');
 
-const sanatizeValues = (inp) => {
+const sanitizeValues = (inp) => {
   if (startsWith$(inp)) return undefined;
 
   if (!isValueObject(inp)) return inp;
@@ -10,7 +10,7 @@ const sanatizeValues = (inp) => {
   if (Array.isArray(inp)) {
     return inp.reduce((arrR, v) => {
       if (isValueObject(v)) {
-        arrR.push(sanatizeValues(v));
+        arrR.push(sanitizeValues(v));
         return arrR;
       }
       if (!startsWith$(v)) {
@@ -27,7 +27,7 @@ const sanatizeValues = (inp) => {
       })
       .reduce((objR, [k, v]) => {
         if (isValueObject(v)) {
-          objR[k] = sanatizeValues(v);
+          objR[k] = sanitizeValues(v);
           return objR;
         }
         objR[k] = v;
@@ -35,4 +35,4 @@ const sanatizeValues = (inp) => {
       }, {});
 };
 
-module.exports = sanatizeValues;
+module.exports = sanitizeValues;

--- a/test/index.js
+++ b/test/index.js
@@ -5,17 +5,17 @@ const sanitizer = require('../src/sanitizer');
 assert(sanitizer(1) === 1, 'Primitive type number is ignored.');
 assert(sanitizer('') === '', 'Empty string is ignored.');
 assert(sanitizer('test') === 'test', 'Normal string is ignored.');
-assert(sanitizer('$lte') === undefined, 'String which starts with $ is ignored.');
+assert(sanitizer('$lte') === undefined, 'String which starts with $ is sanitized.');
 assert(sanitizer(true) === true, 'Boolean "true" stays true.');
-assert(sanitizer(Infinity) === Infinity, 'Boolean "Infinity" stays Infinity.');
+assert(sanitizer(Infinity) === Infinity, 'Infinity stays Infinity.');
 assert(sanitizer(false) === false, 'Boolean "false" stays false.');
-assert(sanitizer(null) === null, 'Object "null" is ignored.');
+assert(sanitizer(null) === null, 'null is ignored.');
 assert(sanitizer(undefined) === undefined, 'undefined stays undefined.');
 assert(JSON.stringify(sanitizer({})) === JSON.stringify({}), 'Empty object stays the same.');
 
 const testObject1 = { a: 1, $gte: 2 };
 const testObject1Sanitized = sanitizer(testObject1);
-assert.deepStrictEqual(testObject1Sanitized,  { a: 1 }, 'Failed to sanitize object 1.');
+assert.deepStrictEqual(testObject1Sanitized, { a: 1 }, 'Failed to sanitize object 1.');
 
 const testObject2Sanitized = sanitizer({
   a: 1,
@@ -43,10 +43,15 @@ assert.deepStrictEqual(
   'Failed to sanitize object 2.'
 );
 
-fastify()
+// Values that start with $ are also stripped
+assert.deepStrictEqual(sanitizer({ url: '$HOME/path' }), {}, 'Object entry with $-prefixed value is stripped.');
+assert.deepStrictEqual(sanitizer(['a', '$b', 'c']), ['a', 'c'], '$-prefixed array elements are stripped.');
+
+const server = fastify();
+server
   .register(require('../index'))
   .post('/:param1key/:param2key', async (req, res) => res.send({ params: req.params, querystring: req.query, body: req.body }))
-  .ready(async (err, server) => {
+  .ready(async (err) => {
     assert(!err, "Server did not initialize correctly.");
 
     async function testServerCall(param1val, param2val, querystring, payload) {
@@ -60,6 +65,7 @@ fastify()
     }
 
     await testServer(testServerCall);
+    await server.close();
   });
 
 
@@ -73,4 +79,23 @@ async function testServer(testServerCall) {
   assert.deepStrictEqual(params, { param2key: 'param2val' }, "Params sanitization failed.");
   assert.deepStrictEqual(querystring, { test: 'a', array: ['c'] }, "Query string sanitization failed.");
   assert.deepStrictEqual(body, { b: 2, c: [{ d: 3 }, {}], f: {} }, "Body sanitization failed.");
+
+  // Test disabling sanitization per field
+  const serverNoParams = fastify();
+  await serverNoParams
+    .register(require('../index'), { params: false, query: false, body: false })
+    .post('/:key', async (req, res) => res.send({ params: req.params, querystring: req.query, body: req.body }))
+    .ready();
+
+  const resDisabled = await serverNoParams.inject({
+    method: 'POST',
+    url: '/$key?$q=1',
+    payload: { $a: 1 },
+  });
+  assert(resDisabled.statusCode === 200, 'Disabled-sanitization server response code is not 200.');
+  const disabledBody = resDisabled.json();
+  assert.deepStrictEqual(disabledBody.params, { key: '$key' }, "Params should not be sanitized when disabled.");
+  assert.deepStrictEqual(disabledBody.querystring, { $q: '1' }, "Query should not be sanitized when disabled.");
+  assert.deepStrictEqual(disabledBody.body, { $a: 1 }, "Body should not be sanitized when disabled.");
+  await serverNoParams.close();
 }


### PR DESCRIPTION
## Summary

- **Typo fix**: `sanatize` → `sanitize` throughout `index.js` and `src/sanitizer.js`
- **Remove stray dependency**: `npm` removed from production dependencies (it is a tool, not a runtime dep)
- **README corrections**: removed false "zero dependencies" claim; fixed "sanatizer" typo
- **ESLint**: changed `globals.browser` → `globals.node` (this is a server-side Node.js package)
- **CI improvements**: added `push`/`pull_request` triggers so tests run on every PR and merge; upgraded `actions/checkout` and `actions/setup-node` from v2 → v4; added Node.js matrix (18, 20, 22); separated `publish` into its own job that only runs on release
- **Tests**: added coverage for disabled sanitization options (`{ params: false, query: false, body: false }`); added assertions documenting `$`-prefixed value stripping behaviour; added `server.close()` after test suite

## Test plan

- [ ] `npm ci && npm test` passes with no assertion errors
- [ ] `npm run lint` reports no issues
- [ ] CI runs on this PR itself (push/pull_request trigger)
- [ ] Confirm `npm` no longer appears under `dependencies` in published package

https://claude.ai/code/session_0196uHh4JPFDNB7EA1uXYPa4

---
_Generated by [Claude Code](https://claude.ai/code/session_0196uHh4JPFDNB7EA1uXYPa4)_